### PR TITLE
Add Telegram share - PoC with SVG icon in footer

### DIFF
--- a/modules/sharedaddy/admin-sharing.css
+++ b/modules/sharedaddy/admin-sharing.css
@@ -122,6 +122,8 @@ li.service.share-email span:before {
 li.service.share-linkedin span:before {
 	content: '\f207';
 }
+li.service.share-telegram span:before {
+}
 li.service.share-twitter span:before {
 	content: '\f202';
 }
@@ -298,6 +300,9 @@ body.settings_page_sharing .advanced input[type=submit] {
 	background-size: 85px 20px;
 	width:85px;
 	height:20px;
+}
+
+.preview-telegram .option-smart-on {
 }
 
 .preview-twitter .option-smart-on {

--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -123,7 +123,7 @@
 				$( '#live-preview div.sharedaddy' ).addClass( 'sd-social-icon' );
 			} else if ( 'official' === button_style ) {
 				$( '#live-preview ul.preview .advanced, .sharing-hidden .inner ul .advanced' ).each( function( /*i*/ ) {
-					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'share-custom' ) ) {
+					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'preview-telegram' ) && !$( this ).hasClass( 'share-custom' ) ) {
 						$( this ).find( '.option a span' ).html( '' ).parent().removeClass( 'sd-button' ).parent().attr( 'class', 'option option-smart-on' );
 					}
 				} );
@@ -346,7 +346,7 @@
 				// Add focus
 				nextSibling.next().focus();
 			}
-			
+
 			//Save changes
 			save_services();
 		}
@@ -370,7 +370,7 @@
 
 			// Move it to the appropriate area and add focus back to service
 			$( '.' + dropzone ).prepend( thisService ).find( 'li:first-child' ).focus();
-			
+
 			//Save changes
 			save_services();
 		}

--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -123,7 +123,7 @@
 				$( '#live-preview div.sharedaddy' ).addClass( 'sd-social-icon' );
 			} else if ( 'official' === button_style ) {
 				$( '#live-preview ul.preview .advanced, .sharing-hidden .inner ul .advanced' ).each( function( /*i*/ ) {
-					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'preview-telegram' ) && !$( this ).hasClass( 'share-custom' ) ) {
+					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'share-custom' ) ) {
 						$( this ).find( '.option a span' ).html( '' ).parent().removeClass( 'sd-button' ).parent().attr( 'class', 'option option-smart-on' );
 					}
 				} );

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -56,6 +56,7 @@ class Sharing_Service {
 			'pinterest'     => 'Share_Pinterest',
 			'pocket'        => 'Share_Pocket',
 			'skype'         => 'Share_Skype',
+			'telegram'      => 'Share_Telegram',
 		);
 
 		if ( $include_custom ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1685,3 +1685,33 @@ class Share_Skype extends Sharing_Source {
 		endif;
 	}
 }
+
+class Share_Telegram extends Sharing_Source {
+	public $shortname = 'telegram';
+	public $genericon = '\f224';
+
+	public function __construct( $id, array $settings ) {
+		parent::__construct( $id, $settings );
+	}
+
+	public function get_name() {
+		return __( 'Telegram', 'jetpack' );
+	}
+
+	public function process_request( $post, array $post_data ) {
+		// Record stats
+		parent::process_request( $post, $post_data );
+
+		$telegram_url = esc_url_raw( 'https://telegram.me/share/url?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&text=' . rawurlencode( $this->get_share_title( $post->ID ) ) );
+		wp_redirect( $telegram_url );
+		exit;
+	}
+
+	public function get_display( $post ) {
+		return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Telegram', 'share to', 'jetpack' ), __( 'Click to share on Telegram', 'jetpack' ), 'share=telegram' );
+	}
+
+	function display_footer() {
+		$this->js_dialog( $this->shortname, array( 'width' => 450, 'height' => 450 ) );
+	}
+}

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1686,6 +1686,13 @@ class Share_Skype extends Sharing_Source {
 	}
 }
 
+/**
+ *
+ * This proof of concept demonstrates use of footer linked SVG icons.
+ *
+ * @todo This is a PoC only and requires cleanup!
+ * @todo Does not support admin preview
+ */
 class Share_Telegram extends Sharing_Source {
 	public $shortname = 'telegram';
 	public $genericon = '\f224';
@@ -1708,10 +1715,29 @@ class Share_Telegram extends Sharing_Source {
 	}
 
 	public function get_display( $post ) {
-		return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Telegram', 'share to', 'jetpack' ), __( 'Click to share on Telegram', 'jetpack' ), 'share=telegram' );
+		//return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Telegram', 'share to', 'jetpack' ), __( 'Click to share on Telegram', 'jetpack' ), 'share=telegram' );
+		return <<<'EOD'
+<a rel="nofollow" data-shared="sharing-telegram-16" class="share-telegram sd-button share-icon" href="" target="_blank" title="Click to share on telegram"><span>
+	<svg><use xlink:href="#telegram"/></svg>
+	Telegram
+</span></a>
+EOD;
 	}
 
 	function display_footer() {
 		$this->js_dialog( $this->shortname, array( 'width' => 450, 'height' => 450 ) );
+?>
+<svg version=1.1>
+	<symbol id=telegram viewBox="0 0 16 16">
+	<g fill-rule="evenodd">
+		<path d="m 16,8 c 0,4.41828 -3.581723,8 -7.9999996,8 C 3.581722,16 0,12.41828 0,8 0,3.58172 3.581722,0 8.0000004,0 12.418277,0 16,3.58172 16,8 Z
+		M 9.7666214,9.82753 C 10.012744,9.15486 10.913951,6.5967 11.058646,5.92577 11.222247,5.16718 10.879762,5.09312 10.100813,5.34755 9.3218644,5.60198 7.3241954,6.3424 6.9879684,6.46174 6.6517404,6.58109 5.0148385,7.13124 4.6754665,7.2954 3.9822941,7.6672 4.3194944,8.23461 5.0944015,8.52923 c 2.3161089,1.11174 1.6584529,0.54521 2.6924759,2.60234 0.212799,0.52552 0.714565,1.42065 1.195136,0.74402 0.252635,-0.38484 0.591058,-1.51908 0.784608,-2.04806 z" />
+	</g>
+	</symbol>
+	<symbol id=telegram-alt viewBox="0 0 16 16">
+		<path d="m 12.865697,10.689248 c 0.579152,-1.5591304 2.699781,-7.4885004 3.040264,-9.0436004 0.38497,-1.75829001 -0.420933,-1.92994001 -2.253878,-1.34021001 -1.832943,0.58973 -6.5336585,2.30589001 -7.3248355,2.58251001 -0.791177,0.27661 -4.642971,1.55178 -5.441547,1.93226 -1.631104,0.86178 -0.837638,2.17693 0.985796,2.85981 5.450035,2.5768304 3.902504,1.26372 6.335664,6.0317804 0.500739,1.21805 1.681444,3.29281 2.8122755,1.7245 0.594476,-0.89198 1.390818,-3.52096 1.846261,-4.74705 z" />
+	</symbol>
+</svg>
+<?php
 	}
 }

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -219,6 +219,13 @@ body .sd-content ul li.share-custom.no-icon a span {
 .sd-social-icon-text .sd-content li.share-linkedin a:before {
 	content: '\f207';
 }
+.share-telegram svg{
+	fill: currentColor;
+	display: inline-block;
+	vertical-align: text-top;
+	width: 16px;
+	height: 16px;
+}
 .sd-social-icon .sd-content ul li.share-twitter a:before,
 .sd-social-text .sd-content ul li.share-twitter a:before,
 .sd-content ul li.share-twitter div.option.option-smart-off a:before,


### PR DESCRIPTION
This simple proof of concept demonstrates an icon with SVG instead of Genericons. Screenshot (Telegram is the SVG, all others are Genericons):

<img width="597" alt="screen shot 2016-05-06 at 19 32 57" src="https://cloud.githubusercontent.com/assets/611339/15089855/e01062ee-13c2-11e6-80fb-3ae2567cb889.png">

The SVG icons are optimized symbols (without color) in the footer. CSS is used to apply the same color as text. The icon itself is injected into the page with: `<svg><use xlink:href="#telegram"/></svg>` this allows many references without the weight of the full icon.

Note: Admin preview not setup.
