### PR TITLE
Add telegram share - PoC with SVG encoded base64 in CSS

### DIFF
--- a/modules/sharedaddy/admin-sharing.css
+++ b/modules/sharedaddy/admin-sharing.css
@@ -300,6 +300,9 @@ body.settings_page_sharing .advanced input[type=submit] {
 	height:20px;
 }
 
+.preview-telegram .option-smart-on {
+}
+
 .preview-twitter .option-smart-on {
 	background: url(images/smart-twitter.png?1) no-repeat top left;
 	background-size: 60px 20px;

--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -123,7 +123,7 @@
 				$( '#live-preview div.sharedaddy' ).addClass( 'sd-social-icon' );
 			} else if ( 'official' === button_style ) {
 				$( '#live-preview ul.preview .advanced, .sharing-hidden .inner ul .advanced' ).each( function( /*i*/ ) {
-					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'share-custom' ) ) {
+					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'preview-telegram' ) && !$( this ).hasClass( 'share-custom' ) ) {
 						$( this ).find( '.option a span' ).html( '' ).parent().removeClass( 'sd-button' ).parent().attr( 'class', 'option option-smart-on' );
 					}
 				} );
@@ -346,7 +346,7 @@
 				// Add focus
 				nextSibling.next().focus();
 			}
-			
+
 			//Save changes
 			save_services();
 		}
@@ -370,7 +370,7 @@
 
 			// Move it to the appropriate area and add focus back to service
 			$( '.' + dropzone ).prepend( thisService ).find( 'li:first-child' ).focus();
-			
+
 			//Save changes
 			save_services();
 		}

--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -123,7 +123,7 @@
 				$( '#live-preview div.sharedaddy' ).addClass( 'sd-social-icon' );
 			} else if ( 'official' === button_style ) {
 				$( '#live-preview ul.preview .advanced, .sharing-hidden .inner ul .advanced' ).each( function( /*i*/ ) {
-					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'preview-telegram' ) && !$( this ).hasClass( 'share-custom' ) ) {
+					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'share-custom' ) ) {
 						$( this ).find( '.option a span' ).html( '' ).parent().removeClass( 'sd-button' ).parent().attr( 'class', 'option option-smart-on' );
 					}
 				} );

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -56,6 +56,7 @@ class Sharing_Service {
 			'pinterest'     => 'Share_Pinterest',
 			'pocket'        => 'Share_Pocket',
 			'skype'         => 'Share_Skype',
+			'telegram'      => 'Share_Telegram',
 		);
 
 		if ( $include_custom ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1685,3 +1685,33 @@ class Share_Skype extends Sharing_Source {
 		endif;
 	}
 }
+
+class Share_Telegram extends Sharing_Source {
+	public $shortname = 'telegram';
+	public $genericon = '\f224';
+
+	public function __construct( $id, array $settings ) {
+		parent::__construct( $id, $settings );
+	}
+
+	public function get_name() {
+		return __( 'Telegram', 'jetpack' );
+	}
+
+	public function process_request( $post, array $post_data ) {
+		// Record stats
+		parent::process_request( $post, $post_data );
+
+		$telegram_url = esc_url_raw( 'https://telegram.me/share/url?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&text=' . rawurlencode( $this->get_share_title( $post->ID ) ) );
+		wp_redirect( $telegram_url );
+		exit;
+	}
+
+	public function get_display( $post ) {
+		return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Telegram', 'share to', 'jetpack' ), __( 'Click to share on Telegram', 'jetpack' ), 'share=telegram' );
+	}
+
+	function display_footer() {
+		$this->js_dialog( $this->shortname, array( 'width' => 450, 'height' => 450 ) );
+	}
+}

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -219,6 +219,16 @@ body .sd-content ul li.share-custom.no-icon a span {
 .sd-social-icon-text .sd-content li.share-linkedin a:before {
 	content: '\f207';
 }
+.sd-social-icon .sd-content ul li.share-telegram a:before,
+.sd-social-text .sd-content ul li.share-telegram a:before,
+.sd-content ul li.share-telegram div.option.option-smart-off a:before,
+.sd-social-icon-text .sd-content li.share-telegram a:before {
+	background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMyIgaGVpZ2h0PSIyMyI+PHBhdGggZD0iTTIzIDExLjVDMjMgMTcuOSAxNy45IDIzIDExLjUgMjMgNS4xIDIzIDAgMTcuOSAwIDExLjUgMCA1LjEgNS4xIDAgMTEuNSAwIDE3LjkgMCAyMyA1LjEgMjMgMTEuNVoiIGZpbGw9IiMyY2E1ZTAiLz48cGF0aCBkPSJNMTQgMTQuMUMxNC40IDEzLjIgMTUuNyA5LjUgMTUuOSA4LjUgMTYuMSA3LjQgMTUuNiA3LjMgMTQuNSA3LjcgMTMuNCA4LjEgMTAuNSA5LjEgMTAgOS4zIDkuNiA5LjUgNy4yIDEwLjMgNi43IDEwLjUgNS43IDExIDYuMiAxMS44IDcuMyAxMi4zYzMuMyAxLjYgMi40IDAuOCAzLjkgMy43IDAuMyAwLjggMSAyIDEuNyAxLjEgMC40LTAuNiAwLjgtMi4yIDEuMS0yLjl6IiBmaWxsPSIjZmZmIi8+PC9zdmc+Cg==');
+	background-size: 1em 1em;
+	width: 1em;
+	height: 1em;
+	content: "";
+}
 .sd-social-icon .sd-content ul li.share-twitter a:before,
 .sd-social-text .sd-content ul li.share-twitter a:before,
 .sd-content ul li.share-twitter div.option.option-smart-off a:before,


### PR DESCRIPTION
This PoC embeds the full SVG in CSS. To have control over sizing, the css property background-image must be used instead of content. Even then, this approach is inflexible with little styling options due to using the pseudo selector ::before. Other approaches are recommended.

Screenshot (Telegram is embedded SVG, all others are Genericon):
<img width="590" alt="screen shot 2016-05-06 at 19 48 43" src="https://cloud.githubusercontent.com/assets/611339/15089917/bcc26024-13c4-11e6-9de6-60a374bc16ce.png">
